### PR TITLE
Clarify eme key status

### DIFF
--- a/eme-extension-policy-check.md
+++ b/eme-extension-policy-check.md
@@ -24,8 +24,9 @@ application developers.
 
 ## Overview
 
-The new API will allow application developers to query the status of an HDCP
-policy without a round-trip to the license server.
+The new API will allow application developers to query the status of a
+hypothetical key associated with an HDCP policy, without the need to fetch a
+real license.
 
 ```
 dictionary MediaKeysPolicyInit {

--- a/eme-extension-policy-check.md
+++ b/eme-extension-policy-check.md
@@ -28,6 +28,14 @@ The new API will allow application developers to query the status of a
 hypothetical key associated with an HDCP policy, without the need to fetch a
 real license.
 
+If HDCP is available at the specified version, the promise should return
+a MediaKeyStatus of "usable". Otherwise, the promise should return
+a MediaKeyStatus of "output-restricted".
+
+A MediaKeyStatus value of "status-pending" must never be returned. Implementers
+must give decisive actionable return values for developers to make decisions
+about what content to fetch.
+
 ```
 dictionary MediaKeysPolicyInit {
   DOMString minHdcpVersion = "";


### PR DESCRIPTION
Responding to feedback. We chose to return MediaKeyStatus (rather than a bool) for extensibility. Later on we may wish to add other license components to the MediaKeysPolicy query and will benefit from the full range of values in MediaKeyStatus.