### PR TITLE
Fix wrong section header levels in Examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -643,7 +643,7 @@ spec: webrtc-pc; urlPrefix: https://www.w3.org/TR/webrtc/#
 
 
 <section>
-  <h3 id='examples'>Examples</h3>
+  <h2 id='examples'>Examples</h2>
 
   <section>
     <h3 id='example1'>Query recording capabilities with {{encodingInfo()}}</h3>


### PR DESCRIPTION
Tiny fix, ToT sections read:

>    3.5 Examples 
>    3.6 Query recording capabilities with encodingInfo()

And it should read:

> 4 Examples
> 4.1Query recording capabilities with encodingInfo()


This PR corrects it.