### PR TITLE
Update minHdcpVersion value

### DIFF
--- a/eme-extension-policy-check.md
+++ b/eme-extension-policy-check.md
@@ -53,9 +53,9 @@ partial interface MediaKeys {
 
 ```js
 video.mediaKeys.getStatusForPolicy({
-  minHdcpVersion: '1.0'
-}).then(function(status) {
-  if (status == 'usable') {
+  minHdcpVersion: 'hdcp-1.0'
+}).then(status => {
+  if (status === 'usable') {
     // Pre-fetch HD content.
   } else {  // such as 'output-restricted' or 'output-downscaled'
     // Pre-fetch SD content.


### PR DESCRIPTION
Until this is decided, we should align `minHdcpVersion` values with Chromium implementation: https://chromium.googlesource.com/chromium/src/+/master/media/blink/webcontentdecryptionmodule_impl.cc#36