### PR TITLE
Upgrade bitrate to 64 bit integer.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -243,7 +243,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
           required DOMString contentType;
           required unsigned long width;
           required unsigned long height;
-          required unsigned long bitrate;
+          required unsigned long long bitrate;
           required DOMString framerate;
         };
       </pre>
@@ -314,7 +314,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
         dictionary AudioConfiguration {
           required DOMString contentType;
           DOMString channels;
-          unsigned long bitrate;
+          unsigned long long bitrate;
           unsigned long samplerate;
         };
       </pre>


### PR DESCRIPTION
Video bitrate already crossed the 4B limit for raw video streams (e.g. 24 bit, 4K @ 60 fps ~ 11 Gbps), compressed streams are catching up (https://en.wikipedia.org/wiki/Ultra_HD_Blu-ray).
Audio bitrate upgraded for the data consistency.