### PR TITLE
Fix a typo in "configuration's framerate"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,7 +265,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
                 finite and greater than 0.
               </li>
               <li>
-                <var>Configuration</var>'{{VideoConfiguration/framerate}}
+                <var>configuration</var>'s {{VideoConfiguration/framerate}}
                 contains one occurence of U+002F SLASH character (/) and the
                 substrings before and after this character, when applying the
                 <a>rules for parsing floating-point number values</a> results in


### PR DESCRIPTION
Also lowercase the variable, even if it'll look funny.