### PR TITLE
Suport querying decodingInfo() for encrypted media.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -57,8 +57,49 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     type: dfn; text: valid mime type; url: valid-mime-type
 
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
-    type: dfn; text: present
+    type: dfn; text: present; url:dfn-present
+
+spec: dom; urlPrefix: https://www.w3.org/TR/dom/#
+    type: dfn; text: Document; url:concept-document
+
+spec: html52; urlPrefix: https://www.w3.org/TR/html52/
+    type: dfn; text: origin; url:browsers.html#concept-cross-origin
+
+
+spec: encrypted-media; urlPrefix: https://www.w3.org/TR/encrypted-media/#
+    type: dfn
+        for: EME; text: encrypted media
+    type: dfn
+        for: EME; text: Key System; url: key-system
+    type: interface
+        for: EME; text: MediaKeySystemAccess; url: mediakeysystemaccess-interface
+    type: interface
+        for: EME; text: MediaKeys; url: mediakeys-interface
+    type: attribute
+        for: EME; text: keySystem; url: dom-mediakeysystemaccess-keysystem
+    type: attribute
+        for: EME; text: initDataTypes; url: dom-mediakeysystemconfiguration-initdatatypes
+    type: attribute
+        for: EME; text: robustness; url: dom-mediakeysystemmediacapability-robustness
+    type: attribute
+        for: EME; text: distinctiveIdentifier; url: dom-mediakeysystemconfiguration-distinctiveidentifier
+    type: attribute
+        for: EME; text: persistentState; url: dom-mediakeysystemconfiguration-persistentstate
+    type: attribute
+        for: EME; text: sessionTypes; url: dom-mediakeysystemconfiguration-sessiontypes
+    type: interface
+        for: EME; text: MediaKeySystemConfiguration; url: mediakeysystemconfiguration-dictionary
+    type: interface
+        for: EME; text: requestMediaKeySystemAccess(); url: navigator-extension:-requestmediakeysystemaccess()
+    type: dfn
+        for: EME; text: Get Supported Configuration; url: get-supported-configuration
+    type: interface
+        for: EME; text: MediaKeySystemMediaCapability; url: mediakeysystemmediacapability-dictionary
+
+spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
+    type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object 
 </pre>
+
 <pre class='biblio'>
 {
     "media-playback-quality": {
@@ -66,6 +107,12 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
         "title": "Media Playback Quality Specification",
         "status": "CG-DRAFT",
         "publisher": "WICG"
+    },
+    "secure-contexts": {
+        "href": "https://www.w3.org/TR/secure-contexts/",
+        "title": "Secure Contexts",
+        "status": "CR",
+        "publisher": "W3C"
     }
 }
 </pre>
@@ -134,6 +181,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
       <pre class='idl'>
         dictionary MediaDecodingConfiguration : MediaConfiguration {
           required MediaDecodingType type;
+          MediaCapabilitiesKeySystemConfiguration keySystemConfiguration;
         };
       </pre>
 
@@ -149,9 +197,19 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
         capabilities by a {{MediaEncodingConfiguration}} dictionary.
       </p>
       <p>
-        For a {{MediaConfiguration}} to be a <dfn>valid
-        MediaConfiguration</dfn>, <code>audio</code> or <code>video</code> MUST
-        be <a>present</a>.
+        For a {{MediaConfiguration}} to be a <dfn>valid MediaConfiguration
+        </dfn>, <code>audio</code> or <code>video</code> MUST be <a>present</a>.
+      </p>
+      <p>
+        For a {{MediaDecodingConfiguration}} to describe <a>encrypted media</a>
+        [[!ENCRYPTED-MEDIA]], a {{keySystemConfiguration}} MUST be 
+        <a>present</a>.
+      </p>
+
+      <p class='note'>
+        {{decodingInfo()}} may only be called with a {{keySystemConfiguration}}
+        <a>present</a> within [[secure-contexts]] and is not available from
+        Workers (FIXME: link? issue?).
       </p>
     </section>
 
@@ -266,7 +324,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
               </li>
               <li>
                 <var>configuration</var>'s {{VideoConfiguration/framerate}}
-                contains one occurence of U+002F SLASH character (/) and the
+                contains one occurrence of U+002F SLASH character (/) and the
                 substrings before and after this character, when applying the
                 <a>rules for parsing floating-point number values</a> results in
                 a number that is finite and greater than 0.
@@ -372,6 +430,71 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
   </section>
 
   <section>
+      <h4 id='mediacapabilitieskeysystemconfiguration'>
+        MediaCapabilitiesKeySystemConfiguration
+      </h4>
+
+      <pre class='idl'>
+      <xmp>
+        dictionary MediaCapabilitiesKeySystemConfiguration {
+          required DOMString keySystem;
+          DOMString initDataType = "";
+          DOMString audioRobustness = "";
+          DOMString videoRobustness = "";
+          MediaKeysRequirement distinctiveIdentifier = "optional";
+          MediaKeysRequirement persistentState = "optional";
+          sequence<DOMString> sessionTypes;
+        };
+      </xmp>
+      </pre>
+
+      <p class='note'>
+        This dictionary refers to a number of types defined by 
+        [[ENCRYPTED-MEDIA]] (EME). Sequences of EME types are 
+        flattened to a single value whenever the intent of the sequence was to 
+        have {{EME/requestMediaKeySystemAccess()}} choose a subset it supports. 
+        With MediaCapabilities, callers provide the sequence across multiple 
+        calls, ultimately letting the caller choose which configuration to use.
+      </p>
+
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>keySystem</dfn> 
+        member represents a {{EME/keySystem}} name as described in 
+        [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>initDataType</dfn>
+        member represents a single value from the {{EME/initDataTypes}} sequence
+        described in [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>audioRobustness</dfn> 
+        member represents an audio {{EME/robustness}} level as described in 
+        [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>videoRobustness</dfn>
+        member represents a video {{EME/robustness}} level as described in 
+        [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>distinctiveIdentifier</dfn>
+        member represents a {{EME/distinctiveIdentifier}} requirement as 
+        described in [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>persistentState</dfn>
+        member represents a {{EME/persistentState}} requirement as described in
+        [[!ENCRYPTED-MEDIA]].
+      </p>
+      <p>
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>sessionTypes</dfn>
+        member represents a sequence of required {{EME/sessionTypes}} as 
+        described in [[!ENCRYPTED-MEDIA]].
+      </p>
+  </section>
+
+  <section>
     <h3 id='media-capabilities-info'>Media Capabilities Information</h3>
 
     <pre class='idl'>
@@ -380,6 +503,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
         readonly attribute boolean supported;
         readonly attribute boolean smooth;
         readonly attribute boolean powerEfficient;
+        readonly attribute MediaKeySystemAccess keySystemAccess;
       };
     </pre>
 
@@ -397,100 +521,6 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
       booleans.
     </p>
 
-    <p>
-      When the <dfn>create a MediaCapabilitiesInfo algorithm</dfn> with a
-      <var>configuration</var> is invoked, the user agent MUST run the following
-      steps:
-      <ol>
-        <li>
-          Let <var>info</var> be a new {{MediaCapabilitiesInfo}} instance.
-          Unless stated otherwise, reading and writing apply to <var>info</var>
-          for the next steps.
-        </li>
-        <li>
-          Set <a for=MediaCapabilitiesInfo>configuration</a> to
-          <var>configuration</var>.
-        </li>
-        <li>
-          If <a for=MediaCapabilitiesInfo>configuration</a> is of type
-          {{MediaDecodingConfiguration}}, run the following substeps:
-          <ol>
-            <li>
-              If the user agent is able to decode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a>, set
-              <a for=MediaCapabilitiesInfo>supported</a> to <code>true</code>.
-              Otherwise set it to <code>false</code>.
-            </li>
-            <li>
-              If the user agent is able to decode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a> at a pace that
-              allows a smooth playback, set <a
-              for=MediaCapabilitiesInfo>smooth</a> to <code>true</code>.
-              Otherwise set it to <code>false</code>.
-            </li>
-            <li>
-              If the user agent is able to decode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a> in a power efficient
-              manner, set <a for=MediaCapabilitiesInfo>powerEfficient</a> to
-              <code>true</code>. Otherwise set it to <code>false</code>. The
-              user agent SHOULD NOT take into consideration the current power
-              source in order to determine the decoding power efficiency unless
-              the device's power source has side effects such as enabling
-              different decoding modules.
-            </li>
-          </ol>
-        </li>
-        <li>
-          If <a for=MediaCapabilitiesInfo>configuration</a> is of type
-          {{MediaEncodingConfiguration}}, run the following substeps:
-          <ol>
-            <li>
-              If the user agent is able to encode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a>, set
-              <a for=MediaCapabilitiesInfo>supported</a> to <code>true</code>.
-              Otherwise set it to <code>false</code>.
-            </li>
-            <li>
-              If the user agent is able to encode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a> at a pace that
-              allows encoding frames at the same pace as they are sent to the
-              encoder, set <a for=MediaCapabilitiesInfo>smooth</a> to
-              <code>true</code>. Otherwise set it to <code>false</code>.
-            </li>
-            <li>
-              If the user agent is able to encode the media represented by
-              <a for=MediaCapabilitiesInfo>configuration</a> in a power
-              efficient manner, set <a
-              for=MediaCapabilitiesInfo>powerEfficient</a> to <code>true</code>.
-              Otherwise set it to <code>false</code>. The user agent SHOULD NOT
-              take into consideration the current power source in order to
-              determine the encoding power efficiency unless the device's power
-              source has side effects such as enabling different encoding
-              modules.
-            </li>
-          </ol>
-          <li>
-            Return <var>info</var>.
-          </li>
-        </li>
-      </ol>
-    </p>
-
-    <p>
-      The <dfn for='MediaCapabilitiesInfo' attribute>supported</dfn> attribute
-      MUST return <a for=MediaCapabilitiesInfo>supported</a>.
-    </p>
-
-    <p>
-      The <dfn for='MediaCapabilitiesInfo' attribute>smooth</dfn> attribute MUST
-      return <a for=MediaCapabilitiesInfo>smooth</a>.
-    </p>
-
-    <p>
-      The <dfn for='MediaCapabilitiesInfo' attribute>powerEfficient</dfn>
-      attribute MUST return <a for=MediaCapabilitiesInfo>powerEfficient</a>.
-    </p>
-
     <p class='note'>
       Authors can use {{MediaCapabilitiesInfo/powerEfficient}} in concordance
       with the Battery Status API [[battery-status]] in order to determine
@@ -499,6 +529,234 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
       constrained, high power usage has side effects such as increasing the
       temperature or the fans noise.
     </p>
+
+    <p>
+      A {{MediaCapabilitiesInfo}} has associated <dfn
+      for='MediaCapabilitiesInfo'>keySystemAccess</dfn> which is a 
+      {{MediaKeySystemAccess}}. This field is only assigned when 
+      {{decodingInfo()}} is called with a {{MediaDecodingConfiguration}} that 
+      has {{keySystemConfiguration}} <a>present</a>. Its value will be 
+      <code>null</code> if the configuration is not 
+      <a for='MediaCapabilitiesInfo'>supported</a>.
+    </p>
+
+    <p class='note'>
+      If the encrypted decoding configuration is supported, the 
+      resulting {{MediaCapabilitiesInfo}} will include a 
+      {{EME/MediaKeySystemAccess}}. Authors may use this to create
+      {{EME/MediaKeys}} and setup encrypted playback.
+    </p>
+
+    <section>
+      <h3 id='info-algorithms'>Algorithms</h3>
+
+      <section>
+        <h4 id='create-media-capabilities-info'>
+          <dfn>Create a MediaCapabilitiesInfo</dfn>
+        </h4>
+        <p>
+          Given a {{MediaConfiguration}} <var>configuration</var>, this 
+          algorithm returns a {{MediaCapabilitiesInfo}}. The following steps are
+          run:
+          <ol>
+            <li>
+              Let <var>info</var> be a new {{MediaCapabilitiesInfo}} instance.
+              Unless stated otherwise, reading and writing apply to 
+              <var>info</var> for the next steps.
+            </li>
+            <li>
+              Set <a for=MediaCapabilitiesInfo>configuration</a> to
+              <var>configuration</var>.
+            </li>
+            <li>
+              If <a for=MediaCapabilitiesInfo>configuration</a> is of type
+              {{MediaDecodingConfiguration}}, run the following substeps:
+              <ol>
+                <li>
+                  If <code>configuration.keySystemConfiguration</code> is 
+                  <a>present</a>:
+                  <ol>
+                    <li>
+                      Set <a for=MediaCapabilitiesInfo>keySystemAccess</a> to 
+                      the result of running the <a>Check Encrypted Decoding Support</a>
+                      algorithm with <var>configuration</var>. 
+                    </li>
+                    <li>
+                      If <a for=MediaCapabilitiesInfo>keySystemAccess</a> is not
+                      <code>null</code> set 
+                      <a for=MediaCapabilitiesInfo>supported</a> to 
+                      <code>true</code>. Otherwise set it to <code>false</code>. 
+                    </li>
+                  </ol>
+
+                  Otherwise, if the user agent is able to decode the media 
+                  represented by <var>configuration</var>, set 
+                  <a for=MediaCapabilitiesInfo>supported</a> to 
+                  <code>true</code>. Otherwise set it to <code>false</code>. 
+                </li>
+                <li>
+                  If the user agent is able to decode the media represented by
+                  <a for=MediaCapabilitiesInfo>configuration</a> (FIXME - here and above, agree on style) at a pace that
+                  allows a smooth playback, set <a
+                  for=MediaCapabilitiesInfo>smooth</a> to <code>true</code>.
+                  Otherwise set it to <code>false</code>.
+                </li>
+                <li>
+                  If the user agent is able to decode the media represented by
+                  <a for=MediaCapabilitiesInfo>configuration</a> in a power efficient
+                  manner, set <a for=MediaCapabilitiesInfo>powerEfficient</a> to
+                  <code>true</code>. Otherwise set it to <code>false</code>. The
+                  user agent SHOULD NOT take into consideration the current power
+                  source in order to determine the decoding power efficiency unless
+                  the device's power source has side effects such as enabling
+                  different decoding modules.
+                </li>
+              </ol>
+            </li>
+            <li>
+              If <a for=MediaCapabilitiesInfo>configuration</a> is of type
+              {{MediaEncodingConfiguration}}, run the following substeps:
+              <ol>
+                <li>
+                  If the user agent is able to encode the media represented by
+                  <a for=MediaCapabilitiesInfo>configuration</a>, set
+                  <a for=MediaCapabilitiesInfo>supported</a> to <code>true</code>.
+                  Otherwise set it to <code>false</code>.
+                </li>
+                <li>
+                  If the user agent is able to encode the media represented by
+                  <a for=MediaCapabilitiesInfo>configuration</a> at a pace that
+                  allows encoding frames at the same pace as they are sent to the
+                  encoder, set <a for=MediaCapabilitiesInfo>smooth</a> to
+                  <code>true</code>. Otherwise set it to <code>false</code>.
+                </li>
+                <li>
+                  If the user agent is able to encode the media represented by
+                  <a for=MediaCapabilitiesInfo>configuration</a> in a power
+                  efficient manner, set <a
+                  for=MediaCapabilitiesInfo>powerEfficient</a> to <code>true</code>.
+                  Otherwise set it to <code>false</code>. The user agent SHOULD NOT
+                  take into consideration the current power source in order to
+                  determine the encoding power efficiency unless the device's power
+                  source has side effects such as enabling different encoding
+                  modules.
+                </li>
+              </ol>
+              <li>
+                Return <var>info</var>.
+              </li>
+            </li>
+          </ol>
+        </p>
+      </section>
+
+      <section>
+        <h4 id='is-encrypted-decode-supported'>
+          <dfn>Check Encrypted Decoding Support</dfn>
+        </h4>
+        <p>
+          Given a {{MediaDecodingConfiguration}} <var>config</var> with a
+          {{keySystemConfiguration}} <a>present</a>, this algorithm returns a
+          {{EME/MediaKeySystemAccess}} or <code>null</code> as appropriate. The
+          following steps are run:
+          <ol>
+            <li>
+              If the {{keySystem}} member of 
+              <var>config.keySystemConfiguration</var> is not one of the 
+              <a for='EME'>Key Systems</a> supported by the user agent, return 
+              <code>null</code>. String comparison is case-sensitive.
+            </li>
+
+            <li>Let <var>document</var> be the calling context's <a>Document</a>.</li>
+            <li>Let <var>origin</var> be the <a>origin</a> of <var>document</var>.
+            <li>Let <var>implementation</var> be the implementation of <var>keySystem</var>.
+
+            <li>
+              Let emeConfig be a new {{EME/MediaKeySystemConfiguration}}, and
+              initialize it as follows:
+            </li>
+            <ol>
+              <li>
+                Set the {{EME/initDataTypes}} attribute to a sequence containing
+                <var>config.keySystemConfiguration.initDataType</var>.
+              </li>
+              <li>
+                Set the {{EME/distinctiveIdentifier}} attribute to 
+                <var>config.keySystemConfiguration.distinctiveIdentifier</var>.
+              </li>
+              <li>
+                Set the {{EME/persistentState}} attribute to 
+                <var>config.keySystemConfiguration.peristentState</var>.
+              </li>
+              <li>
+                Set the {{EME/sessionTypes}} attribute to
+                <var>config.keySystemConfiguration.sessionTypes</var>.
+              </li>
+              <li>
+                If an {{audio}} is <a>present</a> in <var>config</var>, set the
+                {{EME/audioCapabilities}} attribute to a sequence containing a
+                single {{EME/MediaKeySystemMediaCapability}}, initialized as 
+                follows:
+                <ol>
+                  <li>
+                    Set the {{EME/contentType}} attribute to 
+                    <code>config.audio.contentType</code>.
+                  </li>
+                  <li>
+                    Set the {{EME/robustness}} attribute to 
+                    <code>config.keySystemConfiguration.audioRobustness</code>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                If a {{video}} is <a>present</a> in <var>config</var>, set the
+                videoCapabilities attribute to a sequence containing a single 
+                {{EME/MediaKeySystemMediaCapability}}, initialized as follows:
+                <ol>
+                  <li>
+                    Set the {{EME/contentType}} attribute to 
+                    <code>config.video.contentType</code>.
+                  </li>
+                  <li>
+                    Set the {{EME/robustness}} attribute to 
+                    <code>config.keySystemConfiguration.videoRobustness</code>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                Let <var>supported configuration</var> be the result of 
+                executing the <a for='EME'>Get Supported Configuration</a> 
+                algorithm on <var>implementation</var>, 
+                <var>emeConfiguration</var>, and <var>origin</var>.
+              </li>
+              <li>
+                If <var>supported configuration</var> is
+                <code>NotSupported</code>, return <code>null</code> and abort
+                these steps.
+              </li>
+              <li>
+                Let <var>access</var> be a new {{EME/MediaKeySystemAccess}}
+                object, and initialize it as follows:
+                <ol>
+                  <li>
+                    Set the {{EME-Access/keySystem}} attribute to 
+                    <var>emeConfig.keySystem</var>.
+                  </li>
+                  <li>
+                    Let the <var>configuration</var> value be
+                    <var>supported configuration</var>.
+                  </li>
+                  <li>
+                    Let the <var>cdm implementation</var> value be 
+                    <var>implementation</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>return <var>access</var></li>
+            </ol>
+          </ol>
+        </p>
+      </section>
   </section>
 
   <section>
@@ -549,17 +807,58 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
           <code>TypeError</code>.
         </li>
         <li>
+          If <var>configuration</var> is of type {{MediaDecodingConfiguration}}
+          and if <code>configuration.keySystemConfiguration</code> is 
+          <a>present</a>, run the following substeps:
+          <ol>
+            <li>
+              If the calling context is a worker environment (FIXME: worker language), return a Promise 
+              rejected with a <code>TypeError</code>.
+            </li>
+            <li>Let <var>document</var> be the calling context's <a>Document</a>.</li>
+            <li>Let <var>origin</var> be the <a>origin</a> of <var>document</var>.</li>
+            <li>
+              Let <var>context</var> be the result of running 
+              <a for>Is the environment settings object settings a secure context?</a>
+              [[!secure-contexts]] with <var>origin</var>.
+            </li>
+            <li>
+              If <var>context</var> is not "Secure", return a Promise rejected
+              with a <code>TypeError</code>.
+            </li>
+            <li>
+              If <code>keySystemConfiguration.audioRobustness</code> is 
+              <a>present</a> and <code>configuration.audio</code> is not 
+              <a>present</a>, return a Promise rejected with a 
+              <code>TypeError</code>. 
+            </li>
+            <li>
+              If <code>keySystemConfiguration.videoRobustness</code> is 
+              <a>present</a> and <code>configuration.video</code> is not 
+              <a>present</a>, return a Promise rejected with a 
+              <code>TypeError</code>. 
+            </li>
+          </ol>
+        </li>
+        <li>
           Let <var>p</var> be a new promise.
         </li>
         <li>
-          <a>In parallel</a>, run the <a>create a MediaCapabilitiesInfo
-          algorithm</a> with <var>configuration</var> and resolve <var>p</var>
+          <a>In parallel</a>, run the <a>Create a MediaCapabilitiesInfo</a>
+          algorithm with <var>configuration</var> and resolve <var>p</var>
           with its result.
         </li>
         <li>
           Return <var>p</var>.
         </li>
       </ol>
+    </p>
+
+    <p class='note'>
+      Note, calling {{decodingInfo()}} with a {{keySystemConfiguration}} present
+      may have user-visible effects, including requests for user consent. Such 
+      calls should only be made when the author intends to create and use a 
+      {{EME/MediaKeys}} object with the provided configuration.
     </p>
   </section>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -58,6 +58,8 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
 
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn; text: present; url:dfn-present
+    type: dfn; text: SecurityError; url:securityerror
+    type: interface; text: DOMException; url:#idl-DOMException
 
 spec: dom; urlPrefix: https://www.w3.org/TR/dom/#
     type: dfn; text: Document; url:concept-document
@@ -831,7 +833,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         <li>
           If <var>configuration</var> is not a <a>valid
           MediaDecodingConfiguration</a>, return a Promise rejected with a 
-          <code>TypeError</code>.
+          newly created {{TypeError}}.
         </li>
         <li>
           If <code>configuration.keySystemConfiguration</code> is 
@@ -839,13 +841,14 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           <ol>
             <li>
               If the <a>global object</a> is of type {{WorkerGlobalScope}},
-              return a Promise rejected with a <code>TypeError</code>.
+              return a Promise rejected with a newly created {{TypeError}}.
             </li>
             <li>
               If the result of running <a>Is the environment settings object 
               settings a secure context?</a> [[!secure-contexts]] with the 
               <a>global object's</a> <a>relevant settings object</a> is not
-              "Secure", return a Promise rejected with a <code>TypeError</code>.
+              "Secure", return a Promise rejected with a newly created 
+              {{DOMException}} whose name is <a>SecurityError</a>.
             </li>
           </ol>
         </li>
@@ -875,7 +878,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
       <ol>
         <li>
           If <var>configuration</var> is not a <a>valid MediaConfiguration</a>,
-          return a Promise rejected with a <code>TypeError</code>.
+          return a Promise rejected with a newly created {{TypeError}}.
         </li>
         <li>
           Let <var>p</var> be a new promise.

--- a/index.bs
+++ b/index.bs
@@ -188,13 +188,48 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         capabilities by a {{MediaEncodingConfiguration}} dictionary.
       </p>
       <p>
-        For a {{MediaConfiguration}} to be a <dfn>valid MediaConfiguration
-        </dfn>, <code>audio</code> or <code>video</code> MUST be <a>present</a>.
+        For a {{MediaConfiguration}} to be a <dfn>valid 
+        MediaConfiguration</dfn>, all of the following conditions MUST be true:
+        <ol>
+          <li>
+            <code>audio</code> and/or <code>video</code> MUST be <a>present</a>.
+          </li>
+          <li>
+            <code>audio</code> MUST be a <a>valid audio configuration</a> if 
+            <a>present</a>.
+          </li>
+          <li>
+            <code>video</code> MUST be a <a>valid video configuration</a> if 
+            <a>present</a>.
+          </li>
+        </ol>
       </p>
       <p>
-        For a {{MediaDecodingConfiguration}} to describe <a>encrypted media</a>
-        [[!ENCRYPTED-MEDIA]], a {{keySystemConfiguration}} MUST be
-        <a>present</a>.
+        For a {{MediaDecodingConfiguration}} to be a <dfn>valid 
+        MediaDecodingConfiguration</dfn>, all of the following conditions MUST
+        be true:
+        <ol>
+          <li>
+            It MUST be a <a>valid MediaConfiguration</a>.
+          </li>
+          <li>
+            If <code>keySystemConfiguration</code> is <a>present</a>:
+            <ol>
+              <li>
+                If <code>keySystemConfiguration.audioRubstness</code> is 
+                <a>present</a>, <code>audio</code> MUST also be <a>present</a>.
+              </li>
+              <li>
+                If <code>keySystemConfiguration.videoRubstness</code> is 
+                <a>present</a>, <code>video</code> MUST also be <a>present</a>.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </p>
+      <p>
+        For a {{MediaDecodingConfiguration}} to describe [[!ENCRYPTED-MEDIA]], a
+        {{keySystemConfiguration}} MUST be <a>present</a>.
       </p>
     </section>
 
@@ -487,7 +522,13 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         required boolean supported;
         required boolean smooth;
         required boolean powerEfficient;
-        MediaKeySystemAccess? keySystemAccess;
+        
+      };
+    </pre>
+
+    <pre class='idl'>
+      dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
+        required MediaKeySystemAccess keySystemAccess;
       };
     </pre>
 
@@ -515,13 +556,9 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
     </p>
 
     <p>
-      A {{MediaCapabilitiesInfo}} has associated <dfn
-      for='MediaCapabilitiesInfo'>keySystemAccess</dfn> which is a
-      {{MediaKeySystemAccess}}. This field is only assigned when
-      {{decodingInfo()}} is called with a {{MediaDecodingConfiguration}} that
-      has {{keySystemConfiguration}} <a>present</a>. Its value will be
-      <code>null</code> if the configuration is not
-      <a for='MediaCapabilitiesInfo'>supported</a>.
+      A {{MediaCapabilitiesDecodingInfo}} has associated <dfn
+      for='MediaCapabilitiesDecodingInfo'>keySystemAccess</dfn> which is a
+      {{EME/MediaKeySystemAccess}} or <code>null</code> as appropriate.
     </p>
 
     <p class='note'>
@@ -539,7 +576,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           <dfn>Create a MediaCapabilitiesInfo</dfn>
         </h4>
         <p>
-          Given a {{MediaConfiguration}} <var>configuration</var>, this
+          Given a {{MediaEncodingConfiguration}} <var>configuration</var>, this
           algorithm returns a {{MediaCapabilitiesInfo}}. The following steps are
           run:
           <ol>
@@ -553,88 +590,96 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
               <var>configuration</var>.
             </li>
             <li>
-              If <var>configuration</var> is of type
-              {{MediaDecodingConfiguration}}, run the following substeps:
+              If the user agent is able to encode the media represented by
+              <var>configuration</var>, set
+              <a for=MediaCapabilitiesInfo>supported</a> to 
+              <code>true</code>. Otherwise set it to <code>false</code>.
+            </li>
+            <li>
+              If the user agent is able to encode the media represented by
+              <var>configuration</var> at a pace that
+              allows encoding frames at the same pace as they are sent to 
+              the encoder, set <a for=MediaCapabilitiesInfo>smooth</a> to
+              <code>true</code>. Otherwise set it to <code>false</code>.
+            </li>
+            <li>
+              If the user agent is able to encode the media represented by
+              <var>configuration</var> in a power
+              efficient manner, set <a
+              for=MediaCapabilitiesInfo>powerEfficient</a> to 
+              <code>true</code>. Otherwise set it to <code>false</code>. 
+              The user agent SHOULD NOT take into consideration the current 
+              power source in order to determine the encoding power 
+              efficiency unless the device's power source has side effects 
+              such as enabling different encoding modules.
+            </li>
+            <li>
+              Return <var>info</var>.
+            </li>
+          </ol>
+        </p>
+      </section>
+
+      <section>
+        <h4 id='create-media-capabilities-decoding-info'>
+          <dfn>Create a MediaCapabilitiesDecodingInfo</dfn>
+        </h4>
+        <p>
+          Given a {{MediaDecodingConfiguration}} <var>configuration</var>, this
+          algorithm returns a {{MediaCapabilitiesDecodingInfo}}. The following 
+          steps are run:
+          <ol>
+            <li>
+              If <code>configuration.keySystemConfiguration</code> is
+              <a>present</a>:
               <ol>
                 <li>
-                  If <code>configuration.keySystemConfiguration</code> is
-                  <a>present</a>:
-                  <ol>
-                    <li>
-                      Set <a for=MediaCapabilitiesInfo>keySystemAccess</a> to
-                      the result of running the <a>Check Encrypted Decoding Support</a>
-                      algorithm with <var>configuration</var>.
-                    </li>
-                    <li>
-                      If <a for=MediaCapabilitiesInfo>keySystemAccess</a> is not
-                      <code>null</code> set
-                      <a for=MediaCapabilitiesInfo>supported</a> to
-                      <code>true</code>. Otherwise set it to <code>false</code>.
-                    </li>
-                  </ol>
+                  Set <a for=MediaCapabilitiesDecodingInfo>keySystemAccess</a>
+                  to the result of running the <a>Check Encrypted Decoding 
+                  Support</a> algorithm with <var>configuration</var>.
                 </li>
                 <li>
-                  Otherwise, run the following steps:
-                  <ol>
-                    <li>
-                      If the user agent is able to decode the media represented
-                      by <var>configuration</var>, set
-                      <a for=MediaCapabilitiesInfo>supported</a> to
-                      <code>true</code>.
-                    </li>
-                    <li>Otherwise, set it to <code>false</code>.</li>
-                  </ol>
-                </li>
-                <li>
-                  If the user agent is able to decode the media represented by
-                  <var>configuration</var> at a pace that allows a smooth
-                  playback, set <a for=MediaCapabilitiesInfo>smooth</a> to 
+                  If <a for=MediaCapabilitiesDecodingInfo>keySystemAccess</a>
+                  is not <code>null</code> set 
+                  <a for=MediaCapabilitiesInfo>supported</a> to 
                   <code>true</code>. Otherwise set it to <code>false</code>.
-                </li>
-                <li>
-                  If the user agent is able to decode the media represented by
-                  <var>configuration</var> in a power efficient
-                  manner, set <a for=MediaCapabilitiesInfo>powerEfficient</a> to
-                  <code>true</code>. Otherwise set it to <code>false</code>. The
-                  user agent SHOULD NOT take into consideration the current power
-                  source in order to determine the decoding power efficiency unless
-                  the device's power source has side effects such as enabling
-                  different decoding modules.
                 </li>
               </ol>
             </li>
             <li>
-              If <var>configuration</var> is of type
-              {{MediaEncodingConfiguration}}, run the following substeps:
+              Otherwise, run the following steps:
               <ol>
                 <li>
-                  If the user agent is able to encode the media represented by
-                  <var>configuration</var>, set
-                  <a for=MediaCapabilitiesInfo>supported</a> to <code>true</code>.
-                  Otherwise set it to <code>false</code>.
+                  Set <a for=MediaCapabilitiesDecodingInfo>keySystemAccess</a>
+                  to <code>null</code>.
                 </li>
                 <li>
-                  If the user agent is able to encode the media represented by
-                  <var>configuration</var> at a pace that
-                  allows encoding frames at the same pace as they are sent to the
-                  encoder, set <a for=MediaCapabilitiesInfo>smooth</a> to
-                  <code>true</code>. Otherwise set it to <code>false</code>.
+                  If the user agent is able to decode the media represented
+                  by <var>configuration</var>, set
+                  <a for=MediaCapabilitiesInfo>supported</a> to
+                  <code>true</code>.
                 </li>
-                <li>
-                  If the user agent is able to encode the media represented by
-                  <var>configuration</var> in a power
-                  efficient manner, set <a
-                  for=MediaCapabilitiesInfo>powerEfficient</a> to <code>true</code>.
-                  Otherwise set it to <code>false</code>. The user agent SHOULD NOT
-                  take into consideration the current power source in order to
-                  determine the encoding power efficiency unless the device's power
-                  source has side effects such as enabling different encoding
-                  modules.
-                </li>
+                <li>Otherwise, set it to <code>false</code>.</li>
               </ol>
-              <li>
-                Return <var>info</var>.
-              </li>
+            </li>
+            <li>
+              If the user agent is able to decode the media represented by
+              <var>configuration</var> at a pace that allows a smooth
+              playback, set <a for=MediaCapabilitiesInfo>smooth</a> to 
+              <code>true</code>. Otherwise set it to <code>false</code>.
+            </li>
+            <li>
+              If the user agent is able to decode the media represented by
+              <var>configuration</var> in a power efficient
+              manner, set <a for=MediaCapabilitiesInfo>powerEfficient</a> to
+              <code>true</code>. Otherwise set it to <code>false</code>. The
+              user agent SHOULD NOT take into consideration the current 
+              power source in order to determine the decoding power 
+              efficiency unless the device's power source has side effects 
+              such as enabling different decoding modules.
+            </li>
+            <li>
+              Return <var>info</var>.
             </li>
           </ol>
         </p>
@@ -775,32 +820,21 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
     <pre class='idl'>
       [Exposed=(Window, Worker)]
       interface MediaCapabilities {
-        [NewObject] Promise&lt;MediaCapabilitiesInfo&gt; decodingInfo(MediaDecodingConfiguration configuration);
+        [NewObject] Promise&lt;MediaCapabilitiesDecodingInfo&gt; decodingInfo(MediaDecodingConfiguration configuration);
         [NewObject] Promise&lt;MediaCapabilitiesInfo&gt; encodingInfo(MediaEncodingConfiguration configuration);
       };
     </pre>
 
     <p>
-      The {{decodingInfo()}} method and the {{encodingInfo()}} method MUST run
-      the following steps:
+      The {{decodingInfo()}} method method MUST run the following steps:
       <ol>
         <li>
-          If <var>configuration</var> is not a <a>valid MediaConfiguration</a>,
-          return a Promise rejected with a <code>TypeError</code>.
-        </li>
-        <li>
-          If <code>configuration.video</code> is <a>present</a> and is not a
-          <a>valid video configuration</a>, return a Promise rejected with a
+          If <var>configuration</var> is not a <a>valid
+          MediaDecodingConfiguration</a>, return a Promise rejected with a 
           <code>TypeError</code>.
         </li>
         <li>
-          If <code>configuration.audio</code> is <a>present</a> and is not a
-          <a>valid audio configuration</a>, return a Promise rejected with a
-          <code>TypeError</code>.
-        </li>
-        <li>
-          If <var>configuration</var> is of type {{MediaDecodingConfiguration}}
-          and if <code>configuration.keySystemConfiguration</code> is
+          If <code>configuration.keySystemConfiguration</code> is 
           <a>present</a>, run the following substeps:
           <ol>
             <li>
@@ -808,25 +842,40 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
               return a Promise rejected with a <code>TypeError</code>.
             </li>
             <li>
-              If the result of running <a>Is the
-              environment settings object settings a secure context?</a> 
-              [[!secure-contexts]] with the <a>global object's</a> <a>relevant 
-              settings object</a> is not "Secure", return a Promise rejected
-              with a <code>TypeError</code>.
-            </li>
-            <li>
-              If <code>keySystemConfiguration.audioRobustness</code> is
-              <a>present</a> and <code>configuration.audio</code> is not
-              <a>present</a>, return a Promise rejected with a
-              <code>TypeError</code>.
-            </li>
-            <li>
-              If <code>keySystemConfiguration.videoRobustness</code> is
-              <a>present</a> and <code>configuration.video</code> is not
-              <a>present</a>, return a Promise rejected with a
-              <code>TypeError</code>.
+              If the result of running <a>Is the environment settings object 
+              settings a secure context?</a> [[!secure-contexts]] with the 
+              <a>global object's</a> <a>relevant settings object</a> is not
+              "Secure", return a Promise rejected with a <code>TypeError</code>.
             </li>
           </ol>
+        </li>
+        <li>
+          Let <var>p</var> be a new promise.
+        </li>
+        <li>
+          <a>In parallel</a>, run the <a>Create a 
+          MediaCapabilitiesDecodingInfo</a> algorithm with 
+          <var>configuration</var> and resolve <var>p</var> with its result.
+        </li>
+        <li>
+          Return <var>p</var>.
+        </li>
+      </ol>
+    </p>
+
+    <p class='note'>
+      Note, calling {{decodingInfo()}} with a {{keySystemConfiguration}} present
+      may have user-visible effects, including requests for user consent. Such
+      calls should only be made when the author intends to create and use a
+      {{EME/MediaKeys}} object with the provided configuration.
+    </p>
+
+    <p>
+      The {{encodingInfo()}} method MUST run the following steps:
+      <ol>
+        <li>
+          If <var>configuration</var> is not a <a>valid MediaConfiguration</a>,
+          return a Promise rejected with a <code>TypeError</code>.
         </li>
         <li>
           Let <var>p</var> be a new promise.
@@ -842,12 +891,6 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
       </ol>
     </p>
 
-    <p class='note'>
-      Note, calling {{decodingInfo()}} with a {{keySystemConfiguration}} present
-      may have user-visible effects, including requests for user consent. Such
-      calls should only be made when the author intends to create and use a
-      {{EME/MediaKeys}} object with the provided configuration.
-    </p>
   </section>
 </section>
 
@@ -1027,8 +1070,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         If an implementation wishes to implement a fingerprint-proof version of
         this specification, it would be recommended to fake a given set of
         capabilities (ie. decode up to 1080p VP9, etc.) instead of returning
-        always yes or always no as the latter approach could considerably degrade
-        the user's experience.
+        always yes or always no as the latter approach could considerably 
+        degrade the user's experience.
       </p>
     </section>
 

--- a/index.bs
+++ b/index.bs
@@ -65,7 +65,6 @@ spec: dom; urlPrefix: https://www.w3.org/TR/dom/#
 spec: html52; urlPrefix: https://www.w3.org/TR/html52/
     type: dfn; text: origin; url:browsers.html#concept-cross-origin
 
-
 spec: encrypted-media; urlPrefix: https://www.w3.org/TR/encrypted-media/#
     type: dfn
         for: EME; text: encrypted media
@@ -97,7 +96,13 @@ spec: encrypted-media; urlPrefix: https://www.w3.org/TR/encrypted-media/#
         for: EME; text: MediaKeySystemMediaCapability; url: mediakeysystemmediacapability-dictionary
 
 spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
-    type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object 
+    type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object
+
+spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/#
+    type: dfn; text: ECMAScript global environment; url: global-environment
+
+spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
+    type: interface; text: WorkerGlobalScope; url: the-workerglobalscope-common-interface
 </pre>
 
 <pre class='biblio'>
@@ -107,12 +112,6 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         "title": "Media Playback Quality Specification",
         "status": "CG-DRAFT",
         "publisher": "WICG"
-    },
-    "secure-contexts": {
-        "href": "https://www.w3.org/TR/secure-contexts/",
-        "title": "Secure Contexts",
-        "status": "CR",
-        "publisher": "W3C"
     }
 }
 </pre>
@@ -202,14 +201,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </p>
       <p>
         For a {{MediaDecodingConfiguration}} to describe <a>encrypted media</a>
-        [[!ENCRYPTED-MEDIA]], a {{keySystemConfiguration}} MUST be 
+        [[!ENCRYPTED-MEDIA]], a {{keySystemConfiguration}} MUST be
         <a>present</a>.
-      </p>
-
-      <p class='note'>
-        {{decodingInfo()}} may only be called with a {{keySystemConfiguration}}
-        <a>present</a> within [[secure-contexts]] and is not available from
-        Workers (FIXME: link? issue?).
       </p>
     </section>
 
@@ -449,17 +442,17 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </pre>
 
       <p class='note'>
-        This dictionary refers to a number of types defined by 
-        [[ENCRYPTED-MEDIA]] (EME). Sequences of EME types are 
-        flattened to a single value whenever the intent of the sequence was to 
-        have {{EME/requestMediaKeySystemAccess()}} choose a subset it supports. 
-        With MediaCapabilities, callers provide the sequence across multiple 
+        This dictionary refers to a number of types defined by
+        [[ENCRYPTED-MEDIA]] (EME). Sequences of EME types are
+        flattened to a single value whenever the intent of the sequence was to
+        have {{EME/requestMediaKeySystemAccess()}} choose a subset it supports.
+        With MediaCapabilities, callers provide the sequence across multiple
         calls, ultimately letting the caller choose which configuration to use.
       </p>
 
       <p>
-        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>keySystem</dfn> 
-        member represents a {{EME/keySystem}} name as described in 
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>keySystem</dfn>
+        member represents a {{EME/keySystem}} name as described in
         [[!ENCRYPTED-MEDIA]].
       </p>
       <p>
@@ -468,18 +461,18 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         described in [[!ENCRYPTED-MEDIA]].
       </p>
       <p>
-        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>audioRobustness</dfn> 
-        member represents an audio {{EME/robustness}} level as described in 
+        The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>audioRobustness</dfn>
+        member represents an audio {{EME/robustness}} level as described in
         [[!ENCRYPTED-MEDIA]].
       </p>
       <p>
         The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>videoRobustness</dfn>
-        member represents a video {{EME/robustness}} level as described in 
+        member represents a video {{EME/robustness}} level as described in
         [[!ENCRYPTED-MEDIA]].
       </p>
       <p>
         The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>distinctiveIdentifier</dfn>
-        member represents a {{EME/distinctiveIdentifier}} requirement as 
+        member represents a {{EME/distinctiveIdentifier}} requirement as
         described in [[!ENCRYPTED-MEDIA]].
       </p>
       <p>
@@ -489,7 +482,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </p>
       <p>
         The <dfn for='MediaCapabilitiesKeySystemConfiguration' dict-member>sessionTypes</dfn>
-        member represents a sequence of required {{EME/sessionTypes}} as 
+        member represents a sequence of required {{EME/sessionTypes}} as
         described in [[!ENCRYPTED-MEDIA]].
       </p>
   </section>
@@ -532,17 +525,17 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <p>
       A {{MediaCapabilitiesInfo}} has associated <dfn
-      for='MediaCapabilitiesInfo'>keySystemAccess</dfn> which is a 
-      {{MediaKeySystemAccess}}. This field is only assigned when 
-      {{decodingInfo()}} is called with a {{MediaDecodingConfiguration}} that 
-      has {{keySystemConfiguration}} <a>present</a>. Its value will be 
-      <code>null</code> if the configuration is not 
+      for='MediaCapabilitiesInfo'>keySystemAccess</dfn> which is a
+      {{MediaKeySystemAccess}}. This field is only assigned when
+      {{decodingInfo()}} is called with a {{MediaDecodingConfiguration}} that
+      has {{keySystemConfiguration}} <a>present</a>. Its value will be
+      <code>null</code> if the configuration is not
       <a for='MediaCapabilitiesInfo'>supported</a>.
     </p>
 
     <p class='note'>
-      If the encrypted decoding configuration is supported, the 
-      resulting {{MediaCapabilitiesInfo}} will include a 
+      If the encrypted decoding configuration is supported, the
+      resulting {{MediaCapabilitiesInfo}} will include a
       {{EME/MediaKeySystemAccess}}. Authors may use this to create
       {{EME/MediaKeys}} and setup encrypted playback.
     </p>
@@ -555,13 +548,13 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           <dfn>Create a MediaCapabilitiesInfo</dfn>
         </h4>
         <p>
-          Given a {{MediaConfiguration}} <var>configuration</var>, this 
+          Given a {{MediaConfiguration}} <var>configuration</var>, this
           algorithm returns a {{MediaCapabilitiesInfo}}. The following steps are
           run:
           <ol>
             <li>
               Let <var>info</var> be a new {{MediaCapabilitiesInfo}} instance.
-              Unless stated otherwise, reading and writing apply to 
+              Unless stated otherwise, reading and writing apply to
               <var>info</var> for the next steps.
             </li>
             <li>
@@ -573,26 +566,33 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               {{MediaDecodingConfiguration}}, run the following substeps:
               <ol>
                 <li>
-                  If <code>configuration.keySystemConfiguration</code> is 
+                  If <code>configuration.keySystemConfiguration</code> is
                   <a>present</a>:
                   <ol>
                     <li>
-                      Set <a for=MediaCapabilitiesInfo>keySystemAccess</a> to 
+                      Set <a for=MediaCapabilitiesInfo>keySystemAccess</a> to
                       the result of running the <a>Check Encrypted Decoding Support</a>
-                      algorithm with <var>configuration</var>. 
+                      algorithm with <var>configuration</var>.
                     </li>
                     <li>
                       If <a for=MediaCapabilitiesInfo>keySystemAccess</a> is not
-                      <code>null</code> set 
-                      <a for=MediaCapabilitiesInfo>supported</a> to 
-                      <code>true</code>. Otherwise set it to <code>false</code>. 
+                      <code>null</code> set
+                      <a for=MediaCapabilitiesInfo>supported</a> to
+                      <code>true</code>. Otherwise set it to <code>false</code>.
                     </li>
                   </ol>
-
-                  Otherwise, if the user agent is able to decode the media 
-                  represented by <var>configuration</var>, set 
-                  <a for=MediaCapabilitiesInfo>supported</a> to 
-                  <code>true</code>. Otherwise set it to <code>false</code>. 
+                </li>
+                <li>
+                  Otherwise, run the following steps:
+                  <ol>
+                    <li>
+                      If the user agent is able to decode the media represented
+                      by <var>configuration</var>, set
+                      <a for=MediaCapabilitiesInfo>supported</a> to
+                      <code>true</code>.
+                    </li>
+                    <li>Otherwise, set it to <code>false</code>.</li>
+                  </ol>
                 </li>
                 <li>
                   If the user agent is able to decode the media represented by
@@ -661,9 +661,9 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           following steps are run:
           <ol>
             <li>
-              If the {{keySystem}} member of 
-              <var>config.keySystemConfiguration</var> is not one of the 
-              <a for='EME'>Key Systems</a> supported by the user agent, return 
+              If the {{keySystem}} member of
+              <var>config.keySystemConfiguration</var> is not one of the
+              <a for='EME'>Key Systems</a> supported by the user agent, return
               <code>null</code>. String comparison is case-sensitive.
             </li>
 
@@ -681,11 +681,11 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                 <var>config.keySystemConfiguration.initDataType</var>.
               </li>
               <li>
-                Set the {{EME/distinctiveIdentifier}} attribute to 
+                Set the {{EME/distinctiveIdentifier}} attribute to
                 <var>config.keySystemConfiguration.distinctiveIdentifier</var>.
               </li>
               <li>
-                Set the {{EME/persistentState}} attribute to 
+                Set the {{EME/persistentState}} attribute to
                 <var>config.keySystemConfiguration.peristentState</var>.
               </li>
               <li>
@@ -695,38 +695,38 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               <li>
                 If an {{audio}} is <a>present</a> in <var>config</var>, set the
                 {{EME/audioCapabilities}} attribute to a sequence containing a
-                single {{EME/MediaKeySystemMediaCapability}}, initialized as 
+                single {{EME/MediaKeySystemMediaCapability}}, initialized as
                 follows:
                 <ol>
                   <li>
-                    Set the {{EME/contentType}} attribute to 
+                    Set the {{EME/contentType}} attribute to
                     <code>config.audio.contentType</code>.
                   </li>
                   <li>
-                    Set the {{EME/robustness}} attribute to 
+                    Set the {{EME/robustness}} attribute to
                     <code>config.keySystemConfiguration.audioRobustness</code>.
                   </li>
                 </ol>
               </li>
               <li>
                 If a {{video}} is <a>present</a> in <var>config</var>, set the
-                videoCapabilities attribute to a sequence containing a single 
+                videoCapabilities attribute to a sequence containing a single
                 {{EME/MediaKeySystemMediaCapability}}, initialized as follows:
                 <ol>
                   <li>
-                    Set the {{EME/contentType}} attribute to 
+                    Set the {{EME/contentType}} attribute to
                     <code>config.video.contentType</code>.
                   </li>
                   <li>
-                    Set the {{EME/robustness}} attribute to 
+                    Set the {{EME/robustness}} attribute to
                     <code>config.keySystemConfiguration.videoRobustness</code>.
                   </li>
                 </ol>
               </li>
               <li>
-                Let <var>supported configuration</var> be the result of 
-                executing the <a for='EME'>Get Supported Configuration</a> 
-                algorithm on <var>implementation</var>, 
+                Let <var>supported configuration</var> be the result of
+                executing the <a for='EME'>Get Supported Configuration</a>
+                algorithm on <var>implementation</var>,
                 <var>emeConfiguration</var>, and <var>origin</var>.
               </li>
               <li>
@@ -739,7 +739,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                 object, and initialize it as follows:
                 <ol>
                   <li>
-                    Set the {{EME-Access/keySystem}} attribute to 
+                    Set the {{EME-Access/keySystem}} attribute to
                     <var>emeConfig.keySystem</var>.
                   </li>
                   <li>
@@ -747,7 +747,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                     <var>supported configuration</var>.
                   </li>
                   <li>
-                    Let the <var>cdm implementation</var> value be 
+                    Let the <var>cdm implementation</var> value be
                     <var>implementation</var>.
                   </li>
                 </ol>
@@ -808,17 +808,18 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         </li>
         <li>
           If <var>configuration</var> is of type {{MediaDecodingConfiguration}}
-          and if <code>configuration.keySystemConfiguration</code> is 
+          and if <code>configuration.keySystemConfiguration</code> is
           <a>present</a>, run the following substeps:
           <ol>
             <li>
-              If the calling context is a worker environment (FIXME: worker language), return a Promise 
-              rejected with a <code>TypeError</code>.
+              If the <a>ECMAScript global environment</a> is of type
+              {{WorkerGlobalScope}}, return a Promise rejected with a
+              <code>TypeError</code>.
             </li>
             <li>Let <var>document</var> be the calling context's <a>Document</a>.</li>
             <li>Let <var>origin</var> be the <a>origin</a> of <var>document</var>.</li>
             <li>
-              Let <var>context</var> be the result of running 
+              Let <var>context</var> be the result of running
               <a for>Is the environment settings object settings a secure context?</a>
               [[!secure-contexts]] with <var>origin</var>.
             </li>
@@ -827,16 +828,16 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               with a <code>TypeError</code>.
             </li>
             <li>
-              If <code>keySystemConfiguration.audioRobustness</code> is 
-              <a>present</a> and <code>configuration.audio</code> is not 
-              <a>present</a>, return a Promise rejected with a 
-              <code>TypeError</code>. 
+              If <code>keySystemConfiguration.audioRobustness</code> is
+              <a>present</a> and <code>configuration.audio</code> is not
+              <a>present</a>, return a Promise rejected with a
+              <code>TypeError</code>.
             </li>
             <li>
-              If <code>keySystemConfiguration.videoRobustness</code> is 
-              <a>present</a> and <code>configuration.video</code> is not 
-              <a>present</a>, return a Promise rejected with a 
-              <code>TypeError</code>. 
+              If <code>keySystemConfiguration.videoRobustness</code> is
+              <a>present</a> and <code>configuration.video</code> is not
+              <a>present</a>, return a Promise rejected with a
+              <code>TypeError</code>.
             </li>
           </ol>
         </li>
@@ -856,8 +857,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <p class='note'>
       Note, calling {{decodingInfo()}} with a {{keySystemConfiguration}} present
-      may have user-visible effects, including requests for user consent. Such 
-      calls should only be made when the author intends to create and use a 
+      may have user-visible effects, including requests for user consent. Such
+      calls should only be made when the author intends to create and use a
       {{EME/MediaKeys}} object with the provided configuration.
     </p>
   </section>

--- a/index.bs
+++ b/index.bs
@@ -94,6 +94,12 @@ spec: encrypted-media; urlPrefix: https://www.w3.org/TR/encrypted-media/#
         for: EME; text: Get Supported Configuration; url: get-supported-configuration
     type: interface
         for: EME; text: MediaKeySystemMediaCapability; url: mediakeysystemmediacapability-dictionary
+    type: interface
+        for: EME; text: MediaKeysRequirement; url: dom-mediakeysrequirement
+    type: interface
+        for: EME; text: audioCapabilities; url: dom-mediakeysystemconfiguration-audiocapabilities
+    type: interface
+        for: EME; text: contentType; url: dom-mediakeysystemmediacapability-contenttype
 
 spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object
@@ -428,17 +434,17 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
       </h4>
 
       <pre class='idl'>
-      <xmp>
-        dictionary MediaCapabilitiesKeySystemConfiguration {
-          required DOMString keySystem;
-          DOMString initDataType = "";
-          DOMString audioRobustness = "";
-          DOMString videoRobustness = "";
-          MediaKeysRequirement distinctiveIdentifier = "optional";
-          MediaKeysRequirement persistentState = "optional";
-          sequence<DOMString> sessionTypes;
-        };
-      </xmp>
+        <xmp>
+          dictionary MediaCapabilitiesKeySystemConfiguration {
+            required DOMString keySystem;
+            DOMString initDataType = "";
+            DOMString audioRobustness = "";
+            DOMString videoRobustness = "";
+            MediaKeysRequirement distinctiveIdentifier = "optional";
+            MediaKeysRequirement persistentState = "optional";
+            sequence<DOMString> sessionTypes;
+          };
+        </xmp>
       </pre>
 
       <p class='note'>
@@ -495,7 +501,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         required boolean supported;
         required boolean smooth;
         required boolean powerEfficient;
-        readonly attribute MediaKeySystemAccess keySystemAccess;
+        MediaKeySystemAccess keySystemAccess;
       };
     </pre>
 
@@ -661,35 +667,41 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           <ol>
             <li>
               If the {{keySystem}} member of
-              <var>config.keySystemConfiguration</var> is not one of the
+              <code>config.keySystemConfiguration</code> is not one of the
               <a for='EME'>Key Systems</a> supported by the user agent, return
               <code>null</code>. String comparison is case-sensitive.
             </li>
 
-            <li>Let <var>document</var> be the calling context's <a>Document</a>.</li>
-            <li>Let <var>origin</var> be the <a>origin</a> of <var>document</var>.
-            <li>Let <var>implementation</var> be the implementation of <var>keySystem</var>.
+            <li>
+              Let <var>document</var> be the calling context's <a>Document</a>.
+            </li>
+            <li>
+              Let <var>origin</var> be the <a>origin</a> of <var>document</var>.
+            </li>
+            <li>
+              Let <var>implementation</var> be the implementation of <code>config.keySystemConfiguration.keySystem</code>
+            </li>
 
             <li>
-              Let emeConfig be a new {{EME/MediaKeySystemConfiguration}}, and
-              initialize it as follows:
+              Let <var>emeConfiguration</var> be a new 
+              {{EME/MediaKeySystemConfiguration}}, and initialize it as follows:
             </li>
             <ol>
               <li>
                 Set the {{EME/initDataTypes}} attribute to a sequence containing
-                <var>config.keySystemConfiguration.initDataType</var>.
+                <code>config.keySystemConfiguration.initDataType</code>.
               </li>
               <li>
                 Set the {{EME/distinctiveIdentifier}} attribute to
-                <var>config.keySystemConfiguration.distinctiveIdentifier</var>.
+                <code>config.keySystemConfiguration.distinctiveIdentifier</code>.
               </li>
               <li>
                 Set the {{EME/persistentState}} attribute to
-                <var>config.keySystemConfiguration.peristentState</var>.
+                <code>config.keySystemConfiguration.peristentState</code>.
               </li>
               <li>
                 Set the {{EME/sessionTypes}} attribute to
-                <var>config.keySystemConfiguration.sessionTypes</var>.
+                <code>config.keySystemConfiguration.sessionTypes</code>.
               </li>
               <li>
                 If an {{audio}} is <a>present</a> in <var>config</var>, set the
@@ -738,15 +750,15 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
                 object, and initialize it as follows:
                 <ol>
                   <li>
-                    Set the {{EME-Access/keySystem}} attribute to
-                    <var>emeConfig.keySystem</var>.
+                    Set the {{EME/keySystem}} attribute to
+                    <code>emeConfiguration.keySystem</code>.
                   </li>
                   <li>
                     Let the <var>configuration</var> value be
                     <var>supported configuration</var>.
                   </li>
                   <li>
-                    Let the <var>cdm implementation</var> value be
+                    Let the <var ignore=''>cdm implementation</var> value be
                     <var>implementation</var>.
                   </li>
                 </ol>
@@ -787,9 +799,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
     </pre>
 
     <p>
-      The <dfn for='MediaCapabilities' method>decodingInfo()</dfn> method and
-      the <dfn for='MediaCapabilities' method>encodingInfo()</dfn> method MUST
-      run the following steps:
+      The {{decodingInfo()}} method and the {{encodingInfo()}} method MUST run
+      the following steps:
       <ol>
         <li>
           If <var>configuration</var> is not a <a>valid MediaConfiguration</a>,

--- a/index.bs
+++ b/index.bs
@@ -63,49 +63,35 @@ spec: dom; urlPrefix: https://www.w3.org/TR/dom/#
     type: dfn; text: Document; url:concept-document
 
 spec: html52; urlPrefix: https://www.w3.org/TR/html52/
-    type: dfn; text: origin; url:browsers.html#concept-cross-origin
+    type: dfn; 
+        text: origin; url:browsers.html#concept-cross-origin
+        text: global object; url:webappapis.html#global-object
+        text: relevant settings object; url:webappapis.html#relevant-settings-object
 
-spec: encrypted-media; urlPrefix: https://www.w3.org/TR/encrypted-media/#
+spec: encrypted-media; for: EME; urlPrefix: https://www.w3.org/TR/encrypted-media/#
+    type: attribute
+        text: keySystem; url: dom-mediakeysystemaccess-keysystem
+        text: initDataTypes; url: dom-mediakeysystemconfiguration-initdatatypes
+        text: robustness; url: dom-mediakeysystemmediacapability-robustness
+        text: distinctiveIdentifier; url: dom-mediakeysystemconfiguration-distinctiveidentifier
+        text: persistentState; url: dom-mediakeysystemconfiguration-persistentstate
+        text: sessionTypes; url: dom-mediakeysystemconfiguration-sessiontypes
     type: dfn
-        for: EME; text: encrypted media
-    type: dfn
-        for: EME; text: Key System; url: key-system
+        text: encrypted media
+        text: Key System; url: key-system
+        text: Get Supported Configuration; url: get-supported-configuration
     type: interface
-        for: EME; text: MediaKeySystemAccess; url: mediakeysystemaccess-interface
-    type: interface
-        for: EME; text: MediaKeys; url: mediakeys-interface
-    type: attribute
-        for: EME; text: keySystem; url: dom-mediakeysystemaccess-keysystem
-    type: attribute
-        for: EME; text: initDataTypes; url: dom-mediakeysystemconfiguration-initdatatypes
-    type: attribute
-        for: EME; text: robustness; url: dom-mediakeysystemmediacapability-robustness
-    type: attribute
-        for: EME; text: distinctiveIdentifier; url: dom-mediakeysystemconfiguration-distinctiveidentifier
-    type: attribute
-        for: EME; text: persistentState; url: dom-mediakeysystemconfiguration-persistentstate
-    type: attribute
-        for: EME; text: sessionTypes; url: dom-mediakeysystemconfiguration-sessiontypes
-    type: interface
-        for: EME; text: MediaKeySystemConfiguration; url: mediakeysystemconfiguration-dictionary
-    type: interface
-        for: EME; text: requestMediaKeySystemAccess(); url: navigator-extension:-requestmediakeysystemaccess()
-    type: dfn
-        for: EME; text: Get Supported Configuration; url: get-supported-configuration
-    type: interface
-        for: EME; text: MediaKeySystemMediaCapability; url: mediakeysystemmediacapability-dictionary
-    type: interface
-        for: EME; text: MediaKeysRequirement; url: dom-mediakeysrequirement
-    type: interface
-        for: EME; text: audioCapabilities; url: dom-mediakeysystemconfiguration-audiocapabilities
-    type: interface
-        for: EME; text: contentType; url: dom-mediakeysystemmediacapability-contenttype
+        text: MediaKeySystemAccess; url: mediakeysystemaccess-interface
+        text: MediaKeys; url: mediakeys-interface
+        text: MediaKeySystemConfiguration; url: mediakeysystemconfiguration-dictionary
+        text: requestMediaKeySystemAccess(); url: navigator-extension:-requestmediakeysystemaccess()
+        text: MediaKeySystemMediaCapability; url: mediakeysystemmediacapability-dictionary
+        text: MediaKeysRequirement; url: dom-mediakeysrequirement
+        text: audioCapabilities; url: dom-mediakeysystemconfiguration-audiocapabilities
+        text: contentType; url: dom-mediakeysystemmediacapability-contenttype
 
 spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object
-
-spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/#
-    type: dfn; text: ECMAScript global environment; url: global-environment
 
 spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
     type: interface; text: WorkerGlobalScope; url: the-workerglobalscope-common-interface
@@ -501,7 +487,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         required boolean supported;
         required boolean smooth;
         required boolean powerEfficient;
-        MediaKeySystemAccess keySystemAccess;
+        MediaKeySystemAccess? keySystemAccess;
       };
     </pre>
 
@@ -567,7 +553,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
               <var>configuration</var>.
             </li>
             <li>
-              If <a for=MediaCapabilitiesInfo>configuration</a> is of type
+              If <var>configuration</var> is of type
               {{MediaDecodingConfiguration}}, run the following substeps:
               <ol>
                 <li>
@@ -601,14 +587,13 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
                 </li>
                 <li>
                   If the user agent is able to decode the media represented by
-                  <a for=MediaCapabilitiesInfo>configuration</a> (FIXME - here and above, agree on style) at a pace that
-                  allows a smooth playback, set <a
-                  for=MediaCapabilitiesInfo>smooth</a> to <code>true</code>.
-                  Otherwise set it to <code>false</code>.
+                  <var>configuration</var> at a pace that allows a smooth
+                  playback, set <a for=MediaCapabilitiesInfo>smooth</a> to 
+                  <code>true</code>. Otherwise set it to <code>false</code>.
                 </li>
                 <li>
                   If the user agent is able to decode the media represented by
-                  <a for=MediaCapabilitiesInfo>configuration</a> in a power efficient
+                  <var>configuration</var> in a power efficient
                   manner, set <a for=MediaCapabilitiesInfo>powerEfficient</a> to
                   <code>true</code>. Otherwise set it to <code>false</code>. The
                   user agent SHOULD NOT take into consideration the current power
@@ -619,25 +604,25 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
               </ol>
             </li>
             <li>
-              If <a for=MediaCapabilitiesInfo>configuration</a> is of type
+              If <var>configuration</var> is of type
               {{MediaEncodingConfiguration}}, run the following substeps:
               <ol>
                 <li>
                   If the user agent is able to encode the media represented by
-                  <a for=MediaCapabilitiesInfo>configuration</a>, set
+                  <var>configuration</var>, set
                   <a for=MediaCapabilitiesInfo>supported</a> to <code>true</code>.
                   Otherwise set it to <code>false</code>.
                 </li>
                 <li>
                   If the user agent is able to encode the media represented by
-                  <a for=MediaCapabilitiesInfo>configuration</a> at a pace that
+                  <var>configuration</var> at a pace that
                   allows encoding frames at the same pace as they are sent to the
                   encoder, set <a for=MediaCapabilitiesInfo>smooth</a> to
                   <code>true</code>. Otherwise set it to <code>false</code>.
                 </li>
                 <li>
                   If the user agent is able to encode the media represented by
-                  <a for=MediaCapabilitiesInfo>configuration</a> in a power
+                  <var>configuration</var> in a power
                   efficient manner, set <a
                   for=MediaCapabilitiesInfo>powerEfficient</a> to <code>true</code>.
                   Otherwise set it to <code>false</code>. The user agent SHOULD NOT
@@ -671,12 +656,9 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
               <a for='EME'>Key Systems</a> supported by the user agent, return
               <code>null</code>. String comparison is case-sensitive.
             </li>
-
             <li>
-              Let <var>document</var> be the calling context's <a>Document</a>.
-            </li>
-            <li>
-              Let <var>origin</var> be the <a>origin</a> of <var>document</var>.
+              Let <var>origin</var> be the <a>origin</a> of the calling 
+              context's <a>Document</a>.
             </li>
             <li>
               Let <var>implementation</var> be the implementation of <code>config.keySystemConfiguration.keySystem</code>
@@ -734,37 +716,37 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
                   </li>
                 </ol>
               </li>
-              <li>
-                Let <var>supported configuration</var> be the result of
-                executing the <a for='EME'>Get Supported Configuration</a>
-                algorithm on <var>implementation</var>,
-                <var>emeConfiguration</var>, and <var>origin</var>.
-              </li>
-              <li>
-                If <var>supported configuration</var> is
-                <code>NotSupported</code>, return <code>null</code> and abort
-                these steps.
-              </li>
-              <li>
-                Let <var>access</var> be a new {{EME/MediaKeySystemAccess}}
-                object, and initialize it as follows:
-                <ol>
-                  <li>
-                    Set the {{EME/keySystem}} attribute to
-                    <code>emeConfiguration.keySystem</code>.
-                  </li>
-                  <li>
-                    Let the <var>configuration</var> value be
-                    <var>supported configuration</var>.
-                  </li>
-                  <li>
-                    Let the <var ignore=''>cdm implementation</var> value be
-                    <var>implementation</var>.
-                  </li>
-                </ol>
-              </li>
-              <li>return <var>access</var></li>
             </ol>
+            <li>
+              Let <var>supported configuration</var> be the result of
+              executing the <a for='EME'>Get Supported Configuration</a>
+              algorithm on <var>implementation</var>,
+              <var>emeConfiguration</var>, and <var>origin</var>.
+            </li>
+            <li>
+              If <var>supported configuration</var> is
+              <code>NotSupported</code>, return <code>null</code> and abort
+              these steps.
+            </li>
+            <li>
+              Let <var>access</var> be a new {{EME/MediaKeySystemAccess}}
+              object, and initialize it as follows:
+              <ol>
+                <li>
+                  Set the {{EME/keySystem}} attribute to
+                  <code>emeConfiguration.keySystem</code>.
+                </li>
+                <li>
+                  Let the <var>configuration</var> value be
+                  <var>supported configuration</var>.
+                </li>
+                <li>
+                  Let the <var ignore=''>cdm implementation</var> value be
+                  <var>implementation</var>.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>access</var></li>
           </ol>
         </p>
       </section>
@@ -822,19 +804,14 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           <a>present</a>, run the following substeps:
           <ol>
             <li>
-              If the <a>ECMAScript global environment</a> is of type
-              {{WorkerGlobalScope}}, return a Promise rejected with a
-              <code>TypeError</code>.
-            </li>
-            <li>Let <var>document</var> be the calling context's <a>Document</a>.</li>
-            <li>Let <var>origin</var> be the <a>origin</a> of <var>document</var>.</li>
-            <li>
-              Let <var>context</var> be the result of running
-              <a for>Is the environment settings object settings a secure context?</a>
-              [[!secure-contexts]] with <var>origin</var>.
+              If the <a>global object</a> is of type {{WorkerGlobalScope}},
+              return a Promise rejected with a <code>TypeError</code>.
             </li>
             <li>
-              If <var>context</var> is not "Secure", return a Promise rejected
+              If the result of running <a>Is the
+              environment settings object settings a secure context?</a> 
+              [[!secure-contexts]] with the <a>global object's</a> <a>relevant 
+              settings object</a> is not "Secure", return a Promise rejected
               with a <code>TypeError</code>.
             </li>
             <li>


### PR DESCRIPTION
Initial commit to add IDL and algorithms for describing encrypted
media (EME). This takes a normative reference on the EME spec and
offloads as much as possible to the existing algorithms there.

There are a handful of FIXME's here to track open issues needing
resolution before merge.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/pull/101.html" title="Last updated on Nov 20, 2018, 1:58 AM GMT (2f791d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/101/feabd16...2f791d7.html" title="Last updated on Nov 20, 2018, 1:58 AM GMT (2f791d7)">Diff</a>