### PR TITLE
Throw InvalidStateError for EME in workers.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -59,7 +59,8 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn; text: present; url:dfn-present
     type: dfn; text: SecurityError; url:securityerror
-    type: interface; text: DOMException; url:#idl-DOMException
+    type: interface; text: DOMException; url:idl-DOMException
+    type: dfn; text: InvalidStateError; url:invalidstateerror
 
 spec: dom; urlPrefix: https://www.w3.org/TR/dom/#
     type: dfn; text: Document; url:concept-document
@@ -841,7 +842,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           <ol>
             <li>
               If the <a>global object</a> is of type {{WorkerGlobalScope}},
-              return a Promise rejected with a newly created {{TypeError}}.
+              return a Promise rejected with a newly created {{DOMException}}
+              whose name is <a>InvalidStateError</a>.
             </li>
             <li>
               If the result of running <a>Is the environment settings object 


### PR DESCRIPTION
TypeError is preferred for invalid input, so its confusing to use for
this reason.

Fixes #106.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/pull/108.html" title="Last updated on Nov 30, 2018, 9:54 PM GMT (b550f9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/108/a16dfb5...b550f9b.html" title="Last updated on Nov 30, 2018, 9:54 PM GMT (b550f9b)">Diff</a>