### PR TITLE
Fix typo in "robustness"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -219,11 +219,11 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
             If <code>keySystemConfiguration</code> is <a>present</a>:
             <ol>
               <li>
-                If <code>keySystemConfiguration.audioRubstness</code> is 
+                If <code>keySystemConfiguration.audioRobustness</code> is 
                 <a>present</a>, <code>audio</code> MUST also be <a>present</a>.
               </li>
               <li>
-                If <code>keySystemConfiguration.videoRubstness</code> is 
+                If <code>keySystemConfiguration.videoRobustness</code> is 
                 <a>present</a>, <code>video</code> MUST also be <a>present</a>.
               </li>
             </ol>


### PR DESCRIPTION
This typo _rubbed_ me the wrong way. (...I'll see myself out. 😅)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MattiasBuelens/media-capabilities/pull/109.html" title="Last updated on Jan 3, 2019, 1:56 PM UTC (2516ec4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/109/9bbcdaa...MattiasBuelens:2516ec4.html" title="Last updated on Jan 3, 2019, 1:56 PM UTC (2516ec4)">Diff</a>