### PR TITLE
Add support for `hasAlphaChannel` in VideoConfiguration.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -318,6 +318,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           required unsigned long height;
           required unsigned long long bitrate;
           required DOMString framerate;
+          boolean hasAlphaChannel;
         };
       </pre>
 
@@ -383,6 +384,16 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         represents the framerate of the video track. The framerate is the number
         of frames used in one second (frames per second). It is represented
         either as a double or as a fraction.
+      </p>
+
+      <p>
+        The <dfn for='VideoConfiguration' dict-member>hasAlphaChannel</dfn> member
+        represents whether the video track contains alpha channel information. If
+        true, the encoded video stream can produce per-pixel alpha channel information
+        when decoded. If false, the video stream cannot produce per-pixel alpha channel
+        information when decoded. If undefined, the UA should determine whether the
+        video stream encodes alpha channel information based on the indicated
+        {{VideoConfiguration/contentType}}, if possible.
       </p>
     </section>
 

--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
         when decoded. If false, the video stream cannot produce per-pixel alpha channel
         information when decoded. If undefined, the UA should determine whether the
         video stream encodes alpha channel information based on the indicated
-        {{VideoConfiguration/contentType}}, if possible.
+        {{VideoConfiguration/contentType}}, if possible. Otherwise, the UA should
+        presume that the video stream cannot produce alpha channel information.
       </p>
     </section>
 


### PR DESCRIPTION
Fixes Issue #112.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jernoble/media-capabilities/pull/114.html" title="Last updated on Jun 3, 2019, 7:16 PM UTC (e1e4e6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/114/66baccc...jernoble:e1e4e6b.html" title="Last updated on Jun 3, 2019, 7:16 PM UTC (e1e4e6b)">Diff</a>